### PR TITLE
Makefile and headers -> cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,4 +336,4 @@ lib/libgfxd/libgfxd.a
 ExporterTest/ExporterTest.a
 ZAPDUtils/ZAPDUtils.a
 .vscode/
-ZAPD/BuildInfo.h
+ZAPD/BuildInfo.cpp

--- a/ExporterTest/Makefile
+++ b/ExporterTest/Makefile
@@ -2,17 +2,16 @@ CXXFLAGS = -Wall -O2 -g -std=c++17
 OBJ = Main.o TextureExporter.o RoomExporter.o CollisionExporter.o
 LIB = ExporterTest.a
 
-CPPFLAGS-$(MT) += -DCONFIG_MT
-CPPFLAGS += $(CPPFLAGS-y)
 
-.PHONY: all
 all: $(LIB)
 
-.PHONY: clean
 clean:
 	rm -f $(OBJ) $(LIB)
 
-.INTERMEDIATE: $(OBJ)
+format:
+	clang-format-11 -i $(CPP_FILES) $(H_FILES)
+
+.PHONY: all clean format
 
 $(OBJ): Main.cpp TextureExporter.cpp RoomExporter.cpp CollisionExporter.cpp
 

--- a/ExporterTest/Makefile
+++ b/ExporterTest/Makefile
@@ -19,4 +19,4 @@ $(LIB): $(OBJ)
 	$(AR) rcs $@ $^
 
 %.o: %.cpp
-	$(COMPILE.c) $(OUTPUT_OPTION) $(CXXFLAGS) $< -I ./ -I ../ZAPD -I ../ZAPDUtils -I ../lib/tinyxml2
+	$(CXX) $(OUTPUT_OPTION) $(CXXFLAGS) -c $< -I ./ -I ../ZAPD -I ../ZAPDUtils -I ../lib/tinyxml2

--- a/ExporterTest/RoomExporter.cpp
+++ b/ExporterTest/RoomExporter.cpp
@@ -27,10 +27,10 @@ void ExporterExample_Room::Save(ZResource* res, fs::path outPath, BinaryWriter* 
 	//MemoryStream* memStream = new MemoryStream();
 	//BinaryWriter* writer = new BinaryWriter(memStream);
 
-	for (int i = 0; i < room->commands.size() * 8; i++)
+	for (size_t i = 0; i < room->commands.size() * 8; i++)
 		writer->Write((uint8_t)0);
 
-	for (int i = 0; i < room->commands.size(); i++)
+	for (size_t i = 0; i < room->commands.size(); i++)
 	{
 		ZRoomCommand* cmd = room->commands[i];
 		

--- a/ExporterTest/TextureExporter.cpp
+++ b/ExporterTest/TextureExporter.cpp
@@ -7,6 +7,6 @@ void ExporterExample_Texture::Save(ZResource* res, fs::path outPath, BinaryWrite
 
 	auto data = tex->parent->GetRawData();
 
-	for (int i = tex->GetRawDataIndex(); i < tex->GetRawDataIndex() + tex->GetRawDataSize(); i++)
+	for (size_t i = tex->GetRawDataIndex(); i < tex->GetRawDataIndex() + tex->GetRawDataSize(); i++)
 		writer->Write(data[i]);
 }

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ OPTIMIZATION_ON ?= 1
 ASAN ?= 0
 DEPRECATION_ON ?= 1
 DEBUG ?= 0
-CXXFLAGS ?= 
-COPYCHECK_ARGS ?= 
+CXXFLAGS ?=
+COPYCHECK_ARGS ?=
 
 CXX := g++
 INC := -I ZAPD -I lib/assimp/include -I lib/elfio -I lib/json/include -I lib/stb -I lib/tinygltf -I lib/libgfxd -I lib/tinyxml2 -I ZAPDUtils
@@ -81,8 +81,8 @@ format:
 build/%.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@
 
-build/ZAPD/Main.o: genbuildinfo ZAPD/Main.cpp
-	$(CXX) $(CXXFLAGS) $(INC) -c ZAPD/Main.cpp -o $@
+build/ZAPD/Main.o: ZAPD/Main.cpp genbuildinfo
+	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@
 
 lib/libgfxd/libgfxd.a:
 	$(MAKE) -C lib/libgfxd

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ ifneq ($(UNAME), Darwin)
     LDFLAGS += -Wl,-export-dynamic -lstdc++fs
 endif
 
-# ZAPD_SRC_DIRS := ZAPD ZAPD/ZRoom ZAPD/ZRoom/Commands ZAPD/Overlays
 ZAPD_SRC_DIRS := $(shell find ZAPD -type d)
 SRC_DIRS = $(ZAPD_SRC_DIRS) lib/tinyxml2
 
@@ -46,7 +45,6 @@ ZAPD_CPP_FILES := $(foreach dir,$(ZAPD_SRC_DIRS),$(wildcard $(dir)/*.cpp))
 ZAPD_H_FILES   := $(foreach dir,$(ZAPD_SRC_DIRS),$(wildcard $(dir)/*.h))
 
 CPP_FILES += $(ZAPD_CPP_FILES) lib/tinyxml2/tinyxml2.cpp
-# O_FILES   := $(CPP_FILES:.cpp=.o)
 O_FILES   := $(foreach f,$(CPP_FILES:.cpp=.o),build/$f)
 
 

--- a/Makefile
+++ b/Makefile
@@ -96,4 +96,4 @@ ZAPDUtils:
 	$(MAKE) -C ZAPDUtils
 
 ZAPD.out: $(O_FILES) lib/libgfxd/libgfxd.a ExporterTest ZAPDUtils
-	$(CXX) $(CXXFLAGS) $(INC) build/ZAPD/BuildInfo.o $(O_FILES) lib/libgfxd/libgfxd.a ZAPDUtils/ZAPDUtils.a -Wl,--whole-archive ExporterTest/ExporterTest.a -Wl,--no-whole-archive -o $@ $(FS_INC) $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) $(INC) $(O_FILES) lib/libgfxd/libgfxd.a ZAPDUtils/ZAPDUtils.a -Wl,--whole-archive ExporterTest/ExporterTest.a -Wl,--no-whole-archive -o $@ $(FS_INC) $(LDFLAGS)

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -23,7 +23,7 @@
 #include <string>
 #include "tinyxml2.h"
 
-extern char gBuildHash[];
+extern const char gBuildHash[];
 
 using namespace tinyxml2;
 

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -1,4 +1,3 @@
-// #include "BuildInfo.h"
 #include <Utils/Directory.h>
 #include <Utils/File.h>
 #include <Utils/Path.h>

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -1,4 +1,4 @@
-#include "BuildInfo.h"
+// #include "BuildInfo.h"
 #include <Utils/Directory.h>
 #include <Utils/File.h>
 #include <Utils/Path.h>
@@ -22,6 +22,8 @@
 
 #include <string>
 #include "tinyxml2.h"
+
+extern char gBuildHash[];
 
 using namespace tinyxml2;
 

--- a/ZAPD/genbuildinfo.py
+++ b/ZAPD/genbuildinfo.py
@@ -15,4 +15,4 @@ with open("ZAPD/BuildInfo.cpp", "w+") as buildFile:
     if args.devel:
         label += " ~ Development version"
     buildFile.write("extern const char gBuildHash[] = \"" + label + "\";\n")
-    #buildFile.write("const char gBuildDate[] = \"" + now.strftime("%Y-%m-%d %H:%M:%S") + "\";\n")
+    #buildFile.write("extern const char gBuildDate[] = \"" + now.strftime("%Y-%m-%d %H:%M:%S") + "\";\n")

--- a/ZAPD/genbuildinfo.py
+++ b/ZAPD/genbuildinfo.py
@@ -9,7 +9,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--devel", action="store_true")
 args = parser.parse_args()
 
-with open("ZAPD/BuildInfo.h", "w+") as buildFile:
+with open("ZAPD/BuildInfo.cpp", "w+") as buildFile:
     label = subprocess.check_output(["git", "describe", "--always"]).strip().decode("utf-8")
     now = datetime.now()
     if args.devel:

--- a/ZAPD/genbuildinfo.py
+++ b/ZAPD/genbuildinfo.py
@@ -14,5 +14,5 @@ with open("ZAPD/BuildInfo.cpp", "w+") as buildFile:
     now = datetime.now()
     if args.devel:
         label += " ~ Development version"
-    buildFile.write("const char gBuildHash[] = \"" + label + "\";\n")
+    buildFile.write("extern const char gBuildHash[] = \"" + label + "\";\n")
     #buildFile.write("const char gBuildDate[] = \"" + now.strftime("%Y-%m-%d %H:%M:%S") + "\";\n")

--- a/ZAPDUtils/Color3b.h
+++ b/ZAPDUtils/Color3b.h
@@ -6,6 +6,16 @@ struct Color3b
 {
 	uint8_t r, g, b;
 
-	Color3b() { r = 0; g = 0; b = 0; };
-	Color3b(uint8_t nR, uint8_t nG, uint8_t nB) { r = nR; g = nG; b = nB; };
+	Color3b()
+	{
+		r = 0;
+		g = 0;
+		b = 0;
+	};
+	Color3b(uint8_t nR, uint8_t nG, uint8_t nB)
+	{
+		r = nR;
+		g = nG;
+		b = nB;
+	};
 };

--- a/ZAPDUtils/Color3b.h
+++ b/ZAPDUtils/Color3b.h
@@ -6,16 +6,6 @@ struct Color3b
 {
 	uint8_t r, g, b;
 
-	Color3b()
-	{
-		r = 0;
-		g = 0;
-		b = 0;
-	};
-	Color3b(uint8_t nR, uint8_t nG, uint8_t nB)
-	{
-		r = nR;
-		g = nG;
-		b = nB;
-	};
+	Color3b() : r(0), g(0), b(0) {}
+	Color3b(uint8_t nR, uint8_t nG, uint8_t nB) : r(nR), g(nG), b(nB) {}
 };

--- a/ZAPDUtils/Makefile
+++ b/ZAPDUtils/Makefile
@@ -1,23 +1,32 @@
 CXXFLAGS = -Wall -O2 -g -std=c++17
-OBJ = Utils/BinaryWriter.o Utils/MemoryStream.o
+
+SRC_DIRS := $(shell find -type d -not -path "*build*")
+CPP_FILES := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.cpp))
+H_FILES := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.h))
+
+O_FILES   := $(foreach f,$(CPP_FILES:.cpp=.o),build/$f)
 LIB = ZAPDUtils.a
 
-CPPFLAGS-$(MT) += -DCONFIG_MT
-CPPFLAGS += $(CPPFLAGS-y)
+# create build directories
+$(shell mkdir -p $(foreach dir,$(SRC_DIRS),build/$(dir)))
 
-.PHONY: all
 all: $(LIB)
 
-.PHONY: clean
 clean:
-	rm -f $(OBJ) $(LIB)
+	rm -rf build $(LIB)
 
-.INTERMEDIATE: $(OBJ)
+format:
+	clang-format-11 -i $(CPP_FILES) $(H_FILES)
 
-$(OBJ): Utils/BinaryReader.cpp Utils/BinaryWriter.cpp Utils/MemoryStream.cpp
+.PHONY: all clean format
 
-$(LIB): $(OBJ)
+$(O_FILES): $(CPP_FILES)
+
+$(LIB): $(O_FILES)
+#	$(info SRC_DIRS is "$(SRC_DIRS)")
+#	$(info CPP_FILES is "$(CPP_FILES)")
+#	$(info O_FILES is "$(O_FILES)")
 	$(AR) rcs $@ $^
 
-%.o: %.cpp
-	$(COMPILE.c) $(OUTPUT_OPTION) $(CXXFLAGS) $< -I ./ -I ../ZAPD -I ../lib/tinyxml2
+build/%.o: %.cpp
+	$(CXX) -c $(OUTPUT_OPTION) $(CXXFLAGS) $<

--- a/ZAPDUtils/Makefile
+++ b/ZAPDUtils/Makefile
@@ -23,9 +23,6 @@ format:
 $(O_FILES): $(CPP_FILES)
 
 $(LIB): $(O_FILES)
-#	$(info SRC_DIRS is "$(SRC_DIRS)")
-#	$(info CPP_FILES is "$(CPP_FILES)")
-#	$(info O_FILES is "$(O_FILES)")
 	$(AR) rcs $@ $^
 
 build/%.o: %.cpp

--- a/ZAPDUtils/StrHash.cpp
+++ b/ZAPDUtils/StrHash.cpp
@@ -1,0 +1,49 @@
+#include "StrHash.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static strhash CRC32B(unsigned char* message, int32_t size)
+{
+	int32_t byte = 0, crc = 0;
+	int32_t mask = 0;
+
+	crc = 0xFFFFFFFF;
+
+	for (int32_t i = 0; i < size; i++)
+	{
+		byte = message[i];
+		crc = crc ^ byte;
+
+		for (int32_t j = 7; j >= 0; j--)
+		{
+			mask = -(crc & 1);
+			crc = (crc >> 1) ^ (0xEDB88320 & mask);
+		}
+	}
+
+	return ~(uint32_t)(crc);
+}
+
+constexpr static strhash CRC32BCT(const char* message, int32_t size)
+{
+	int32_t byte = 0, crc = 0;
+	int32_t mask = 0;
+
+	crc = 0xFFFFFFFF;
+
+	for (int32_t i = 0; i < size; i++)
+	{
+		byte = message[i];
+		crc = crc ^ byte;
+
+		for (int32_t j = 7; j >= 0; j--)
+		{
+			mask = -(crc & 1);
+			crc = (crc >> 1) ^ (0xEDB88320 & mask);
+		}
+	}
+
+	return ~(uint32_t)(crc);
+}

--- a/ZAPDUtils/StrHash.h
+++ b/ZAPDUtils/StrHash.h
@@ -6,46 +6,5 @@
 
 typedef uint32_t strhash;
 
-static strhash CRC32B(unsigned char* message, int32_t size)
-{
-	int32_t byte = 0, crc = 0;
-	int32_t mask = 0;
-
-	crc = 0xFFFFFFFF;
-
-	for (int32_t i = 0; i < size; i++)
-	{
-		byte = message[i];
-		crc = crc ^ byte;
-
-		for (int32_t j = 7; j >= 0; j--)
-		{
-			mask = -(crc & 1);
-			crc = (crc >> 1) ^ (0xEDB88320 & mask);
-		}
-	}
-
-	return ~(uint32_t)(crc);
-}
-
-constexpr static strhash CRC32BCT(const char* message, int32_t size)
-{
-	int32_t byte = 0, crc = 0;
-	int32_t mask = 0;
-
-	crc = 0xFFFFFFFF;
-
-	for (int32_t i = 0; i < size; i++)
-	{
-		byte = message[i];
-		crc = crc ^ byte;
-
-		for (int32_t j = 7; j >= 0; j--)
-		{
-			mask = -(crc & 1);
-			crc = (crc >> 1) ^ (0xEDB88320 & mask);
-		}
-	}
-
-	return ~(uint32_t)(crc);
-}
+static strhash CRC32B(unsigned char* message, int32_t size);
+constexpr static strhash CRC32BCT(const char* message, int32_t size);

--- a/ZAPDUtils/Utils/BinaryReader.cpp
+++ b/ZAPDUtils/Utils/BinaryReader.cpp
@@ -1,6 +1,5 @@
-#pragma once
-
 #include "BinaryReader.h"
+
 #include "Stream.h"
 
 BinaryReader::BinaryReader(Stream* nStream)

--- a/ZAPDUtils/Utils/BinaryReader.cpp
+++ b/ZAPDUtils/Utils/BinaryReader.cpp
@@ -128,7 +128,7 @@ std::string BinaryReader::ReadString()
 {
 	std::string res = "";
 	char c;
-		
+
 	do
 	{
 		c = ReadChar();
@@ -136,7 +136,6 @@ std::string BinaryReader::ReadString()
 		if (c != 0)
 			res += c;
 	} while (c != 0);
-
 
 	return res;
 }

--- a/ZAPDUtils/Utils/BinaryReader.h
+++ b/ZAPDUtils/Utils/BinaryReader.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "Stream.h"
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+#include "../Color3b.h"
 #include "../Vec2f.h"
 #include "../Vec3f.h"
 #include "../Vec3s.h"
-#include "../Color3b.h"
-#include <memory>
-#include <array>
-#include <vector>
-#include <string>
+#include "Stream.h"
 
 class BinaryReader
 {
@@ -16,7 +16,7 @@ public:
 	BinaryReader(Stream* nStream);
 
 	void Close();
-		
+
 	void Seek(uint32_t offset, SeekOffsetType seekType);
 	uint32_t GetBaseAddress();
 
@@ -37,7 +37,7 @@ public:
 	Vec2f ReadVec2f();
 	Color3b ReadColor3b();
 	std::string ReadString();
-	
+
 protected:
 	std::shared_ptr<Stream> stream;
 };

--- a/ZAPDUtils/Utils/Directory.cpp
+++ b/ZAPDUtils/Utils/Directory.cpp
@@ -1,0 +1,31 @@
+#include "Directory.h"
+
+#include <string>
+#include <vector>
+#include "StringHelper.h"
+
+std::string Directory::GetCurrentDirectory()
+{
+	return fs::current_path().u8string();
+}
+
+bool Directory::Exists(const fs::path& path)
+{
+	return fs::exists(path);
+}
+
+void Directory::CreateDirectory(const std::string& path)
+{
+	std::string curPath = "";
+	std::vector<std::string> split = StringHelper::Split(path, "/");
+
+	for (std::string s : split)
+	{
+		curPath += s + "/";
+
+		if (!Exists(curPath))
+			fs::create_directory(curPath);
+	}
+
+	// fs::create_directory(path);
+}

--- a/ZAPDUtils/Utils/Directory.h
+++ b/ZAPDUtils/Utils/Directory.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <iostream>
 #include <string>
-#include <vector>
 
 #if __has_include(<filesystem>)
 #include <filesystem>
@@ -17,23 +15,7 @@ namespace fs = std::experimental::filesystem;
 class Directory
 {
 public:
-	static std::string GetCurrentDirectory() { return fs::current_path().u8string(); }
-
-	static bool Exists(const fs::path& path) { return fs::exists(path); }
-
-	static void CreateDirectory(const std::string& path)
-	{
-		std::string curPath = "";
-		std::vector<std::string> split = StringHelper::Split(path, "/");
-
-		for (std::string s : split)
-		{
-			curPath += s + "/";
-
-			if (!Exists(curPath))
-				fs::create_directory(curPath);
-		}
-
-		// fs::create_directory(path);
-	}
+	static std::string GetCurrentDirectory();
+	static bool Exists(const fs::path& path);
+	static void CreateDirectory(const std::string& path);
 };

--- a/ZAPDUtils/Utils/File.cpp
+++ b/ZAPDUtils/Utils/File.cpp
@@ -1,0 +1,81 @@
+#include "File.h"
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
+#include <fstream>
+#include <stdio.h>
+#include <cstring>
+#include <string>
+#include <vector>
+#include "StringHelper.h"
+
+bool File::Exists(const fs::path& filePath)
+{
+	std::ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
+	return file.good();
+}
+
+std::vector<uint8_t> File::ReadAllBytes(const fs::path& filePath)
+{
+	std::ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
+	int32_t fileSize = (int32_t)file.tellg();
+	file.seekg(0);
+	char* data = new char[fileSize];
+	file.read(data, fileSize);
+	std::vector<uint8_t> result = std::vector<uint8_t>(data, data + fileSize);
+	delete[] data;
+
+	return result;
+};
+
+std::string File::ReadAllText(const fs::path& filePath)
+{
+	std::ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
+	int32_t fileSize = (int32_t)file.tellg();
+	file.seekg(0);
+	char* data = new char[fileSize + 1];
+	memset(data, 0, fileSize + 1);
+	file.read(data, fileSize);
+	std::string str = std::string((const char*)data);
+	delete[] data;
+
+	return str;
+};
+
+std::vector<std::string> File::ReadAllLines(const fs::path& filePath)
+{
+	std::string text = ReadAllText(filePath);
+	std::vector<std::string> lines = StringHelper::Split(text, "\n");
+
+	return lines;
+};
+
+void File::WriteAllBytes(const fs::path& filePath, const std::vector<uint8_t>& data)
+{
+	std::ofstream file(filePath, std::ios::binary);
+	file.write((char*)data.data(), data.size());
+};
+
+void File::WriteAllBytes(const std::string& filePath, const std::vector<char>& data)
+{
+	std::ofstream file(filePath, std::ios::binary);
+	file.write((char*)data.data(), data.size());
+};
+
+void File::WriteAllBytes(const std::string& filePath, const char* data, int dataSize)
+{
+	std::ofstream file(filePath, std::ios::binary);
+	file.write((char*)data, dataSize);
+};
+
+void File::WriteAllText(const fs::path& filePath, const std::string& text)
+{
+	std::ofstream file(filePath, std::ios::out);
+	file.write(text.c_str(), text.size());
+}

--- a/ZAPDUtils/Utils/File.h
+++ b/ZAPDUtils/Utils/File.h
@@ -1,78 +1,26 @@
 #pragma once
 
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
 #include <fstream>
-#include <iostream>
-#include <stdio.h>
 #include <string>
 #include <vector>
-#include "Directory.h"
-#include "Utils/StringHelper.h"
 
 class File
 {
 public:
-	static bool Exists(const fs::path& filePath)
-	{
-		std::ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
-		return file.good();
-	}
-
-	static std::vector<uint8_t> ReadAllBytes(const fs::path& filePath)
-	{
-		std::ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
-		int32_t fileSize = (int32_t)file.tellg();
-		file.seekg(0);
-		char* data = new char[fileSize];
-		file.read(data, fileSize);
-		std::vector<uint8_t> result = std::vector<uint8_t>(data, data + fileSize);
-		delete[] data;
-
-		return result;
-	};
-
-	static std::string ReadAllText(const fs::path& filePath)
-	{
-		std::ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
-		int32_t fileSize = (int32_t)file.tellg();
-		file.seekg(0);
-		char* data = new char[fileSize + 1];
-		memset(data, 0, fileSize + 1);
-		file.read(data, fileSize);
-		std::string str = std::string((const char*)data);
-		delete[] data;
-
-		return str;
-	};
-
-	static std::vector<std::string> ReadAllLines(const fs::path& filePath)
-	{
-		std::string text = ReadAllText(filePath);
-		std::vector<std::string> lines = StringHelper::Split(text, "\n");
-
-		return lines;
-	};
-
-	static void WriteAllBytes(const fs::path& filePath, const std::vector<uint8_t>& data)
-	{
-		std::ofstream file(filePath, std::ios::binary);
-		file.write((char*)data.data(), data.size());
-	};
-
-	static void WriteAllBytes(const std::string& filePath, const std::vector<char>& data)
-	{
-		std::ofstream file(filePath, std::ios::binary);
-		file.write((char*)data.data(), data.size());
-	};
-
-	static void WriteAllBytes(const std::string& filePath, const char* data, int dataSize)
-	{
-		std::ofstream file(filePath, std::ios::binary);
-		file.write((char*)data, dataSize);
-	};
-
-	static void WriteAllText(const fs::path& filePath, const std::string& text)
-	{
-		std::ofstream file(filePath, std::ios::out);
-		file.write(text.c_str(), text.size());
-	}
+	static bool Exists(const fs::path& filePath);
+	static std::vector<uint8_t> ReadAllBytes(const fs::path& filePath);
+	static std::string ReadAllText(const fs::path& filePath);
+	static std::vector<std::string> ReadAllLines(const fs::path& filePath);
+	static void WriteAllBytes(const fs::path& filePath, const std::vector<uint8_t>& data);
+	static void WriteAllBytes(const std::string& filePath, const std::vector<char>& data);
+	static void WriteAllBytes(const std::string& filePath, const char* data, int dataSize);
+	static void WriteAllText(const fs::path& filePath, const std::string& text);
 };

--- a/ZAPDUtils/Utils/Path.cpp
+++ b/ZAPDUtils/Utils/Path.cpp
@@ -1,0 +1,40 @@
+#include "Path.h"
+
+#include <string>
+#include "StringHelper.h"
+
+std::string Path::GetFileName(const std::string& input)
+{
+	std::vector<std::string> split = StringHelper::Split(input, "/");
+	return split[split.size() - 1];
+}
+
+std::string Path::GetFileNameWithoutExtension(const std::string& input)
+{
+	std::vector<std::string> split = StringHelper::Split(input, "/");
+	return split[split.size() - 1].substr(0, split[split.size() - 1].find_last_of("."));
+}
+
+std::string Path::GetFileNameExtension(const std::string& input)
+{
+	return input.substr(input.find_last_of("."), input.length());
+}
+
+std::string Path::GetPath(const std::string& input)
+{
+	std::vector<std::string> split = StringHelper::Split(input, "/");
+	std::string output = "";
+
+	for (std::string str : split)
+	{
+		if (str.find_last_of(".") == std::string::npos)
+			output += str + "/";
+	}
+
+	return output;
+}
+
+std::string Path::GetDirectoryName(const fs::path& path)
+{
+	return path.parent_path().u8string();
+}

--- a/ZAPDUtils/Utils/Path.h
+++ b/ZAPDUtils/Utils/Path.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <iostream>
 #include <string>
-#include "Utils/StringHelper.h"
 
 #if __has_include(<filesystem>)
 #include <filesystem>
@@ -15,39 +13,9 @@ namespace fs = std::experimental::filesystem;
 class Path
 {
 public:
-	static std::string GetFileName(const std::string& input)
-	{
-		std::vector<std::string> split = StringHelper::Split(input, "/");
-		return split[split.size() - 1];
-	};
-
-	static std::string GetFileNameWithoutExtension(const std::string& input)
-	{
-		std::vector<std::string> split = StringHelper::Split(input, "/");
-		return split[split.size() - 1].substr(0, split[split.size() - 1].find_last_of("."));
-	};
-
-	static std::string GetFileNameExtension(const std::string& input)
-	{
-		return input.substr(input.find_last_of("."), input.length());
-	};
-
-	static std::string GetPath(const std::string& input)
-	{
-		std::vector<std::string> split = StringHelper::Split(input, "/");
-		std::string output = "";
-
-		for (std::string str : split)
-		{
-			if (str.find_last_of(".") == std::string::npos)
-				output += str + "/";
-		}
-
-		return output;
-	};
-
-	static std::string GetDirectoryName(const fs::path& path)
-	{
-		return path.parent_path().u8string();
-	};
+	static std::string GetFileName(const std::string& input);
+	static std::string GetFileNameWithoutExtension(const std::string& input);
+	static std::string GetFileNameExtension(const std::string& input);
+	static std::string GetPath(const std::string& input);
+	static std::string GetDirectoryName(const fs::path& path);
 };

--- a/ZAPDUtils/Utils/Stream.cpp
+++ b/ZAPDUtils/Utils/Stream.cpp
@@ -1,0 +1,8 @@
+#include "Stream.h"
+
+#include <stdint.h>
+
+uint64_t Stream::GetBaseAddress()
+{
+	return baseAddress;
+}

--- a/ZAPDUtils/Utils/Stream.h
+++ b/ZAPDUtils/Utils/Stream.h
@@ -21,7 +21,7 @@ class Stream
 {
 public:
 	virtual uint64_t GetLength() = 0;
-	uint64_t GetBaseAddress() { return baseAddress; }
+	uint64_t GetBaseAddress();
 
 	virtual void Seek(int32_t offset, SeekOffsetType seekType) = 0;
 

--- a/ZAPDUtils/Utils/StringHelper.cpp
+++ b/ZAPDUtils/Utils/StringHelper.cpp
@@ -1,0 +1,104 @@
+#include "StringHelper.h"
+
+#include <algorithm>
+#include <cstring>
+#include <numeric>
+#include <stdarg.h>
+#include <string>
+#include <vector>
+
+std::vector<std::string> StringHelper::Split(std::string s, const std::string& delimiter)
+{
+    std::vector<std::string> result;
+
+    size_t pos = 0;
+    std::string token;
+
+    while ((pos = s.find(delimiter)) != std::string::npos)
+    {
+        token = s.substr(0, pos);
+        result.push_back(token);
+        s.erase(0, pos + delimiter.length());
+    }
+
+    if (s.length() != 0)
+        result.push_back(s);
+
+    return result;
+}
+
+std::string StringHelper::Strip(std::string s, const std::string& delimiter)
+{
+    size_t pos = 0;
+    std::string token;
+
+    while ((pos = s.find(delimiter)) != std::string::npos)
+    {
+        token = s.substr(0, pos);
+        s.erase(pos, pos + delimiter.length());
+    }
+
+    return s;
+}
+
+std::string StringHelper::Replace(std::string str, const std::string& from, const std::string& to)
+{
+    size_t start_pos = str.find(from);
+
+    if (start_pos == std::string::npos)
+        return str;
+
+    str.replace(start_pos, from.length(), to);
+    return str;
+}
+
+bool StringHelper::StartsWith(const std::string& s, const std::string& input)
+{
+    return s.rfind(input, 0) == 0;
+}
+
+bool StringHelper::Contains(const std::string& s, const std::string& input)
+{
+    return s.find(input) != std::string::npos;
+}
+
+bool StringHelper::EndsWith(const std::string& s, const std::string& input)
+{
+    size_t inputLen = strlen(input.c_str());
+    return s.rfind(input) == (s.size() - inputLen);
+}
+
+std::string StringHelper::Sprintf(const char* format, ...)
+{
+    char buffer[0x8000];
+    // char buffer[0x800];
+    std::string output = "";
+    va_list va;
+
+    va_start(va, format);
+    vsprintf(buffer, format, va);
+    va_end(va);
+
+    output = buffer;
+    return output;
+}
+
+std::string StringHelper::Implode(std::vector<std::string>& elements, const char* const separator)
+{
+    return std::accumulate(std::begin(elements), std::end(elements), std::string(),
+                            [separator](std::string& ss, std::string& s) {
+                                return ss.empty() ? s : ss + separator + s;
+                            });
+}
+
+int64_t StringHelper::StrToL(const std::string& str, int32_t base)
+{
+    return std::strtoull(str.c_str(), nullptr, base);
+}
+
+std::string StringHelper::BoolStr(bool b) { return b ? "true" : "false"; }
+
+bool StringHelper::HasOnlyDigits(const std::string& str)
+{
+    return std::all_of(str.begin(), str.end(), ::isdigit);
+}

--- a/ZAPDUtils/Utils/StringHelper.h
+++ b/ZAPDUtils/Utils/StringHelper.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <algorithm>
 #include <cstring>
-#include <numeric>
 #include <stdarg.h>
 #include <string>
 #include <vector>
@@ -18,99 +16,15 @@
 class StringHelper
 {
 public:
-	static std::vector<std::string> Split(std::string s, const std::string& delimiter)
-	{
-		std::vector<std::string> result;
-
-		size_t pos = 0;
-		std::string token;
-
-		while ((pos = s.find(delimiter)) != std::string::npos)
-		{
-			token = s.substr(0, pos);
-			result.push_back(token);
-			s.erase(0, pos + delimiter.length());
-		}
-
-		if (s.length() != 0)
-			result.push_back(s);
-
-		return result;
-	}
-
-	static std::string Strip(std::string s, const std::string& delimiter)
-	{
-		size_t pos = 0;
-		std::string token;
-
-		while ((pos = s.find(delimiter)) != std::string::npos)
-		{
-			token = s.substr(0, pos);
-			s.erase(pos, pos + delimiter.length());
-		}
-
-		return s;
-	}
-
-	static std::string Replace(std::string str, const std::string& from, const std::string& to)
-	{
-		size_t start_pos = str.find(from);
-
-		if (start_pos == std::string::npos)
-			return str;
-
-		str.replace(start_pos, from.length(), to);
-		return str;
-	}
-
-	static bool StartsWith(const std::string& s, const std::string& input)
-	{
-		return s.rfind(input, 0) == 0;
-	}
-
-	static bool Contains(const std::string& s, const std::string& input)
-	{
-		return s.find(input) != std::string::npos;
-	}
-
-	static bool EndsWith(const std::string& s, const std::string& input)
-	{
-		size_t inputLen = strlen(input.c_str());
-		return s.rfind(input) == (s.size() - inputLen);
-	}
-
-	static std::string Sprintf(const char* format, ...)
-	{
-		char buffer[32768];
-		// char buffer[2048];
-		std::string output = "";
-		va_list va;
-
-		va_start(va, format);
-		vsprintf(buffer, format, va);
-		va_end(va);
-
-		output = buffer;
-		return output;
-	}
-
-	static std::string Implode(std::vector<std::string>& elements, const char* const separator)
-	{
-		return std::accumulate(std::begin(elements), std::end(elements), std::string(),
-		                       [separator](std::string& ss, std::string& s) {
-								   return ss.empty() ? s : ss + separator + s;
-							   });
-	}
-
-	static int64_t StrToL(const std::string& str, int32_t base = 10)
-	{
-		return std::strtoull(str.c_str(), nullptr, base);
-	}
-
-	static std::string BoolStr(bool b) { return b ? "true" : "false"; }
-
-	static bool HasOnlyDigits(const std::string& str)
-	{
-		return std::all_of(str.begin(), str.end(), ::isdigit);
-	}
+	static std::vector<std::string> Split(std::string s, const std::string& delimiter);
+	static std::string Strip(std::string s, const std::string& delimiter);
+	static std::string Replace(std::string str, const std::string& from, const std::string& to);
+	static bool StartsWith(const std::string& s, const std::string& input);
+	static bool Contains(const std::string& s, const std::string& input);
+	static bool EndsWith(const std::string& s, const std::string& input);
+	static std::string Sprintf(const char* format, ...);
+	static std::string Implode(std::vector<std::string>& elements, const char* const separator);
+	static int64_t StrToL(const std::string& str, int32_t base = 10);
+	static std::string BoolStr(bool b);
+	static bool HasOnlyDigits(const std::string& str);
 };

--- a/ZAPDUtils/Vec2f.h
+++ b/ZAPDUtils/Vec2f.h
@@ -6,6 +6,14 @@ struct Vec2f
 {
 	float x, y;
 
-	Vec2f() { x = 0; y = 0; };
-	Vec2f(float nX, float nY) { x = nX; y = nY; };
+	Vec2f()
+	{
+		x = 0;
+		y = 0;
+	};
+	Vec2f(float nX, float nY)
+	{
+		x = nX;
+		y = nY;
+	};
 };

--- a/ZAPDUtils/Vec2f.h
+++ b/ZAPDUtils/Vec2f.h
@@ -6,14 +6,6 @@ struct Vec2f
 {
 	float x, y;
 
-	Vec2f()
-	{
-		x = 0;
-		y = 0;
-	};
-	Vec2f(float nX, float nY)
-	{
-		x = nX;
-		y = nY;
-	};
+	Vec2f() : x(0), y(0) {}
+	Vec2f(float nX, float nY) : x(nX), y(nY) {}
 };

--- a/ZAPDUtils/Vec3f.h
+++ b/ZAPDUtils/Vec3f.h
@@ -6,6 +6,16 @@ struct Vec3f
 {
 	float x, y, z;
 
-	Vec3f() { x = 0; y = 0; z = 0; };
-	Vec3f(float nX, float nY, float nZ) { x = nX; y = nY; z = nZ; };
+	Vec3f()
+	{
+		x = 0;
+		y = 0;
+		z = 0;
+	};
+	Vec3f(float nX, float nY, float nZ)
+	{
+		x = nX;
+		y = nY;
+		z = nZ;
+	};
 };

--- a/ZAPDUtils/Vec3f.h
+++ b/ZAPDUtils/Vec3f.h
@@ -6,16 +6,6 @@ struct Vec3f
 {
 	float x, y, z;
 
-	Vec3f()
-	{
-		x = 0;
-		y = 0;
-		z = 0;
-	};
-	Vec3f(float nX, float nY, float nZ)
-	{
-		x = nX;
-		y = nY;
-		z = nZ;
-	};
+	Vec3f() : x(0), y(0), z(0) {}
+	Vec3f(float nX, float nY, float nZ) : x(nX), y(nY), z(nZ) {}
 };

--- a/ZAPDUtils/Vec3s.h
+++ b/ZAPDUtils/Vec3s.h
@@ -6,16 +6,6 @@ struct Vec3s
 {
 	int16_t x, y, z;
 
-	Vec3s()
-	{
-		x = 0;
-		y = 0;
-		z = 0;
-	};
-	Vec3s(int16_t nX, int16_t nY, int16_t nZ)
-	{
-		x = nX;
-		y = nY;
-		z = nZ;
-	};
+	Vec3s() : x(0), y(0), z(0) {}
+	Vec3s(int16_t nX, int16_t nY, int16_t nZ) : x(nX), y(nY), z(nZ) {}
 };


### PR DESCRIPTION
- Change the calls to the recursive makes to .PHONY on the folders rather than the library files. This is apparently the idiomatic way of doing it. It will thus always call their makes, which will decide for themselves to remake stuff
- Switched to CXX consistently
- Use build folders for ZAPD and ZAPDUtils. Segregating the files like this makes some of the rules and variables easier to define.
- Made some proper variables so we don't have to worry about adding specific files. I'm not completely sure about := vs =, someone more experienced will hopefully have a clearer idea.
- Changed the buildinfo to use a cpp file instead of a h to keep data out of headers.
- Fixed the -Wall warnings in ExporterTests because they were driving me batty while testing.
- Make cpp files for most of the header-only files in ZAPDUtils and move code over.